### PR TITLE
fix: wire docker-entrypoint.sh into container ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,6 @@ COPY . .
 
 RUN uv sync --no-dev --frozen
 
-ENTRYPOINT ["uv", "run", "dpulse"]
+RUN chmod +x /app/docker-entrypoint.sh
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -48,4 +48,4 @@ if [ -d /app/service/pdf_report_templates ]; then
   done
 fi
 
-exec python /app/dpulse.py
+exec uv run dpulse "$@"


### PR DESCRIPTION
The `docker-entrypoint.sh` script initializes config files, dorking DBs, and PDF templates from the image into the user's mounted volume — but the Dockerfile bypasses it entirely with `ENTRYPOINT ["uv", "run", "dpulse"]`.

This means users running the container with `-v "$PWD":/data -w /data` never get their `service/config.ini` or DB files initialized, which likely causes a broken first-run experience.

**Changes:**
- Set `ENTRYPOINT` to `/app/docker-entrypoint.sh` and `chmod +x` it during build
- Update the entrypoint's final `exec` call from `python /app/dpulse.py` to `uv run dpulse` to stay consistent with the project's uv-based toolchain