### PR TITLE
fix: Chromium auto-detection, CAPTCHA handling, subdomain sentinel string, SecurityTrails→PageSearch fallback

### DIFF
--- a/apis/api_securitytrails.py
+++ b/apis/api_securitytrails.py
@@ -13,7 +13,7 @@ def securitytrails_html_prep(formatted_output):
         formatted_output = formatted_output[:start_index] + formatted_output[end_index:]
     return formatted_output
 
-def check_domain_securitytrails(domain, api_key):
+def check_domain_securitytrails(domain, api_key, return_subdomains=False):
     api_key = api_key.strip()
     api_key = re.sub(r'[\s\u200B\uFEFF]+', '', api_key)
 
@@ -24,7 +24,10 @@ def check_domain_securitytrails(domain, api_key):
         general_response = requests.get(general_url)
         general_data = general_response.json()
     except Exception as e:
-        return Fore.RED + f"Error while parsing JSON: {e}" + Style.RESET_ALL
+        error_output = Fore.RED + f"Error while parsing JSON: {e}" + Style.RESET_ALL
+        if return_subdomains:
+            return error_output, []
+        return error_output
 
     formatted_output = Fore.LIGHTBLUE_EX + "=== SECURITYTRAILS API REPORT ===\n" + Style.RESET_ALL
     formatted_output += f"\n{Fore.LIGHTBLUE_EX}[+] Domain General Information:{Style.RESET_ALL}\n"
@@ -75,6 +78,7 @@ def check_domain_securitytrails(domain, api_key):
                     f"{Fore.GREEN}Value: {Style.RESET_ALL}{Fore.LIGHTCYAN_EX}{txt_value}{Style.RESET_ALL}\n"
                 )
 
+    alive_subdomains = []
     subdomains_response = requests.get(subdomains_url)
     if subdomains_response.status_code == 200:
         subdomains_data = subdomains_response.json()
@@ -91,11 +95,13 @@ def check_domain_securitytrails(domain, api_key):
             formatted_output += f"{Fore.GREEN}Subdomains list:{Style.RESET_ALL}\n"
             alive_count = 0
             for i, subdomain in enumerate(subdomains, start=1):
-                subdomain_url = f"http://{subdomain}.{domain}"
+                fqdn = f"{subdomain}.{domain}"
+                subdomain_url = f"http://{fqdn}"
                 try:
                     r = requests.get(subdomain_url, timeout=5)
                     if r.status_code == 200:
                         alive_count += 1
+                        alive_subdomains.append(fqdn)
                         formatted_output += (
                             f"{Fore.GREEN}{i}. {Style.RESET_ALL}{Fore.LIGHTCYAN_EX}{subdomain_url}{Style.RESET_ALL}"
                             f"{Fore.GREEN} is alive{Style.RESET_ALL}\n"
@@ -110,10 +116,12 @@ def check_domain_securitytrails(domain, api_key):
     else:
         formatted_output += (f"{Fore.RED}Error while gathering subdomains: {subdomains_response.status_code}{Style.RESET_ALL}\n")
 
+    if return_subdomains:
+        return formatted_output, alive_subdomains
     return formatted_output
 
 
-def api_securitytrails_check(domain):
+def api_securitytrails_check(domain, return_subdomains=False):
     conn = sqlite3.connect('apis//api_keys.db')
     cursor = conn.cursor()
     cursor.execute("SELECT api_name, api_key FROM api_keys")
@@ -132,9 +140,14 @@ def api_securitytrails_check(domain):
     if not api_key:
         print(Fore.RED + "SecurityTrails API key not found." + Style.RESET_ALL)
         conn.close()
-        return None
+        return (None, []) if return_subdomains else None
 
-    formatted_output = check_domain_securitytrails(domain, api_key)
+    result = check_domain_securitytrails(domain, api_key, return_subdomains=return_subdomains)
     conn.close()
-    print(formatted_output)
-    return formatted_output
+    if return_subdomains:
+        formatted_output, alive_subdomains = result
+        print(formatted_output)
+        return formatted_output, alive_subdomains
+
+    print(result)
+    return result

--- a/datagather_modules/crawl_processor.py
+++ b/datagather_modules/crawl_processor.py
@@ -90,15 +90,11 @@ def subdomains_gather(url, short_domain):
         finder = short_domain
         subdomains = [urllib.parse.unquote(i) for i in linked_domains if finder in i]
         subdomains_amount = len(subdomains)
-        if not subdomains:
-            subdomains = ['No subdomains were found']
-            logging.info('SUBDOMAINS GATHERING: OK')
         return subdomains, subdomains_amount
     except Exception as e:
         print(Fore.RED + f"Cannot gather subdomains due to error. See journal for details" + Style.RESET_ALL)
         logging.error(f'SUBDOMAINS GATHERING: ERROR. REASON: {e}')
-        pass
-        return ['No subdomains were found'], 0
+        return [], 0
 
 def sm_gather(url):
     social_domains = {
@@ -158,35 +154,31 @@ def domains_reverse_research(subdomains, report_file_type):
     subdomain_socials = []
     subdomain_ip = []
 
-    try:
-        for subdomain in subdomains:
-            subdomain_url = "http://" + subdomain + "/"
-            subdomain_urls.append(subdomain_url)
-    except Exception as e:
-        print(Fore.RED + "Some URL seems unreachable! DPULSE will continue to work, but the URL causing the error won't be included in report. See journal for details" + Style.RESET_ALL)
-        logging.error(f'SUBDOMAINS URL FORMING: ERROR. REASON: {e}')
-        pass
+    for subdomain in subdomains:
+        try:
+            subdomain_urls.append("http://" + subdomain + "/")
+        except Exception as e:
+            logging.warning(f'SUBDOMAINS URL FORMING: skipped invalid subdomain {subdomain}. REASON: {e}')
 
-    try:
-        for subdomain in subdomains:
+    for subdomain in subdomains:
+        try:
             subdomains_ip = ip_gather(subdomain)
             subdomain_ip.append(subdomains_ip)
-            subdomain_ip = list(set(subdomain_ip))
-    except Exception as e:
-        print(Fore.RED + "Some URL seems unreachable! DPULSE will continue to work, but the URL causing the error won't be included in report. See journal for details" + Style.RESET_ALL)
-        logging.error(f'SUBDOMAINS IP GATHERING: ERROR. REASON: {e}')
-        pass
+        except Exception as e:
+            logging.warning(f'SUBDOMAINS IP GATHERING: skipped unreachable subdomain {subdomain}. REASON: {e}')
+    subdomain_ip = list(set(subdomain_ip))
 
-    try:
-        for subdomain_url in subdomain_urls:
+    for subdomain_url in subdomain_urls:
+        try:
             subdomain_mail = subdomains_mail_gather(subdomain_url)
             subdomain_mails.append(subdomain_mail)
+        except Exception as e:
+            logging.warning(f'SUBDOMAINS MAIL GATHERING: skipped unreachable subdomain URL {subdomain_url}. REASON: {e}')
+        try:
             subdomain_social = sm_gather(subdomain_url)
             subdomain_socials.append(subdomain_social)
-    except Exception as e:
-        print(Fore.RED + "Some URL seems unreachable! DPULSE will continue to work, but the URL causing the error won't be included in report. See journal for details" + Style.RESET_ALL)
-        logging.error(f'SUBDOMAINS MAIL/SOCIALS GATHERING: ERROR. REASON: {e}')
-        pass
+        except Exception as e:
+            logging.warning(f'SUBDOMAINS SOCIALS GATHERING: skipped unreachable subdomain URL {subdomain_url}. REASON: {e}')
 
     subdomain_mails = [sublist for sublist in subdomain_mails if sublist]
     subdomain_mails = [sublist for sublist in subdomain_mails if sublist != [None]]

--- a/datagather_modules/data_assembler.py
+++ b/datagather_modules/data_assembler.py
@@ -54,6 +54,39 @@ def is_real_url(value: str) -> bool:
     return parsed.scheme in ('http', 'https') and bool(parsed.netloc)
 
 
+def run_pagesearch(report_folder, subdomains, keywords, keywords_flag):
+    print(Fore.LIGHTMAGENTA_EX + "[STARTED EXTENDED DOMAIN SCAN WITH PAGESEARCH]" + Style.RESET_ALL)
+    (
+        ps_emails_return,
+        accessible_subdomains,
+        emails_amount,
+        files_counter,
+        cookies_counter,
+        api_keys_counter,
+        website_elements_counter,
+        exposed_passwords_counter,
+        keywords_messages_list
+    ), ps_string = subdomains_parser(subdomains, report_folder, keywords, keywords_flag)
+    total_links_counter = accessed_links_counter = "No results because PageSearch does not gather these categories"
+    if len(keywords_messages_list) == 0:
+        keywords_messages_list = ['No keywords were found']
+    print(Fore.LIGHTMAGENTA_EX + "[ENDED EXTENDED DOMAIN SCAN WITH PAGESEARCH]\n" + Style.RESET_ALL)
+    return (
+        ps_emails_return,
+        accessible_subdomains,
+        emails_amount,
+        files_counter,
+        cookies_counter,
+        api_keys_counter,
+        website_elements_counter,
+        exposed_passwords_counter,
+        total_links_counter,
+        accessed_links_counter,
+        keywords_messages_list,
+        ps_string,
+    )
+
+
 def establishing_dork_db_connection(dorking_flag):
     dorking_db_paths = {
         'basic': 'dorking//basic_dorking.db',
@@ -205,10 +238,10 @@ class DataProcessing():
         print(Fore.LIGHTMAGENTA_EX + "[ENDED BASIC DOMAIN SCAN]\n" + Style.RESET_ALL)
 
         if report_file_type == 'html':
+            pending_pagesearch = False
+            securitytrails_subdomains = []
             if pagesearch_flag.lower() == 'y':
-                if subdomains and subdomains[0] != 'No subdomains were found':
-                    to_search_array = [subdomains, social_medias, sd_socials]
-                    print(Fore.LIGHTMAGENTA_EX + "[STARTED EXTENDED DOMAIN SCAN WITH PAGESEARCH]" + Style.RESET_ALL)
+                if subdomains:
                     (
                         ps_emails_return,
                         accessible_subdomains,
@@ -218,16 +251,13 @@ class DataProcessing():
                         api_keys_counter,
                         website_elements_counter,
                         exposed_passwords_counter,
-                        keywords_messages_list
-                    ), ps_string = subdomains_parser(
-                        to_search_array[0], report_folder, keywords, keywords_flag
-                    )
-                    total_links_counter = accessed_links_counter = "No results because PageSearch does not gather these categories"
-                    if len(keywords_messages_list) == 0:
-                        keywords_messages_list = ['No keywords were found']
-                    print(Fore.LIGHTMAGENTA_EX + "[ENDED EXTENDED DOMAIN SCAN WITH PAGESEARCH]\n" + Style.RESET_ALL)
+                        total_links_counter,
+                        accessed_links_counter,
+                        keywords_messages_list,
+                        ps_string,
+                    ) = run_pagesearch(report_folder, subdomains, keywords, keywords_flag)
                 else:
-                    print(Fore.RED + "Cant start PageSearch because no subdomains were detected\n")
+                    pending_pagesearch = True
                     ps_emails_return = ""
                     accessible_subdomains = files_counter = cookies_counter = api_keys_counter = \
                         website_elements_counter = exposed_passwords_counter = total_links_counter = \
@@ -263,7 +293,7 @@ class DataProcessing():
                     virustotal_output = 'No results because user did not selected VirusTotal API scan'
 
                 if '2' in used_api_flag:
-                    securitytrails_output = api_securitytrails_check(short_domain)
+                    securitytrails_output, securitytrails_subdomains = api_securitytrails_check(short_domain, return_subdomains=True)
                     api_scan_db.append('SecurityTrails')
                 else:
                     securitytrails_output = 'No results because user did not selected SecurityTrails API scan'
@@ -282,6 +312,27 @@ class DataProcessing():
                 securitytrails_output = 'No results because user did not selected SecurityTrails API scan'
                 hudsonrock_output = 'No results because user did not selected HudsonRock API scan'
                 api_scan_db.append('No')
+
+            if pending_pagesearch and securitytrails_subdomains:
+                subdomains = securitytrails_subdomains
+                subdomains_amount = len(securitytrails_subdomains)
+                print(Fore.LIGHTMAGENTA_EX + "[PAGESEARCH FALLBACK] Using SecurityTrails subdomains because the initial crawl found none." + Style.RESET_ALL)
+                (
+                    ps_emails_return,
+                    accessible_subdomains,
+                    emails_amount,
+                    files_counter,
+                    cookies_counter,
+                    api_keys_counter,
+                    website_elements_counter,
+                    exposed_passwords_counter,
+                    total_links_counter,
+                    accessed_links_counter,
+                    keywords_messages_list,
+                    ps_string,
+                ) = run_pagesearch(report_folder, securitytrails_subdomains, keywords, keywords_flag)
+            elif pending_pagesearch:
+                print(Fore.RED + "Cant start PageSearch because no subdomains were detected\n")
 
             if snapshotting_flag.lower() in ['s', 'p', 'w']:
                 config_values = read_config()

--- a/dorking/dorking_handler.py
+++ b/dorking/dorking_handler.py
@@ -2,6 +2,9 @@ import sys
 import random
 import time
 import os
+import re
+import shutil
+import subprocess
 import logging
 from colorama import Fore, Style
 import undetected_chromedriver as uc
@@ -14,6 +17,88 @@ from ua_rotator import user_agent_rotator
 from proxies_rotator import proxies_rotator
 from config_processing import read_config
 
+
+GOOGLE_BLOCKED = '__GOOGLE_BLOCKED__'
+GOOGLE_BLOCK_WAIT_SECS = 300
+GOOGLE_BLOCK_POLL_SECS = 5
+
+
+def resolve_browser_binary(configured_path):
+    if configured_path:
+        normalized_path = configured_path.strip()
+        if normalized_path and normalized_path.lower() not in {'none', 'path\\to\\browser\\for\\dorking'} and os.path.isfile(normalized_path):
+            return normalized_path
+
+    for browser_name in ('google-chrome', 'google-chrome-stable', 'chromium', 'chromium-browser'):
+        browser_path = shutil.which(browser_name)
+        if browser_path:
+            return browser_path
+
+    return None
+
+
+def resolve_browser_major_version(browser_binary):
+    if not browser_binary:
+        return None
+
+    try:
+        version_output = subprocess.check_output([browser_binary, '--version'], text=True).strip()
+    except Exception:
+        return None
+
+    version_match = re.search(r'(\d+)\.', version_output)
+    if version_match:
+        return int(version_match.group(1))
+
+    return None
+
+
+def is_google_block_page(driver):
+    try:
+        current_url = (driver.current_url or '').lower()
+        page_source = (driver.page_source or '').lower()
+    except Exception:
+        return False
+
+    return (
+        '/sorry/' in current_url
+        or 'captcha-form' in page_source
+        or 'our systems have detected unusual traffic' in page_source
+        or 'detected unusual traffic from your computer network' in page_source
+    )
+
+
+def report_google_block(query):
+    logging.warning(f'DORKING PROCESSING: Google block page detected for query: {query}')
+    print(Fore.LIGHTYELLOW_EX + 'Google presented a bot-check / CAPTCHA page. Automated dorking was stopped for this run.' + Style.RESET_ALL)
+    return GOOGLE_BLOCKED
+
+
+def handle_google_block(driver, query, dorking_browser_mode):
+    if dorking_browser_mode.lower() != 'nonheadless':
+        return report_google_block(query)
+
+    logging.warning(f'DORKING PROCESSING: Google block page detected for query in manual mode: {query}')
+    print(Fore.LIGHTYELLOW_EX + 'Google presented a bot-check / CAPTCHA page.' + Style.RESET_ALL)
+    print(Fore.LIGHTYELLOW_EX + 'Solve it in the opened browser window. DPULSE will keep the browser open and resume automatically.' + Style.RESET_ALL)
+    print(Fore.LIGHTYELLOW_EX + f'Waiting up to {GOOGLE_BLOCK_WAIT_SECS} seconds. Press Ctrl+C to cancel dorking.' + Style.RESET_ALL)
+
+    deadline = time.time() + GOOGLE_BLOCK_WAIT_SECS
+    while time.time() < deadline:
+        time.sleep(GOOGLE_BLOCK_POLL_SECS)
+        try:
+            if not is_google_block_page(driver):
+                print(Fore.GREEN + 'Google challenge cleared. Resuming dorking...' + Style.RESET_ALL)
+                return None
+        except Exception:
+            return report_google_block(query)
+
+        remaining_seconds = max(0, int(deadline - time.time()))
+        print(Fore.LIGHTYELLOW_EX + f'Google challenge is still active. Waiting... ({remaining_seconds}s remaining)' + Style.RESET_ALL)
+
+    print(Fore.LIGHTYELLOW_EX + 'Timed out while waiting for the Google challenge to be solved.' + Style.RESET_ALL)
+    return report_google_block(query)
+
 def proxy_transfer():
     proxy_flag, proxies_list = proxies_rotator.get_proxies()
     if proxy_flag == 0:
@@ -23,32 +108,48 @@ def proxy_transfer():
         working_proxies = proxies_rotator.check_proxies(proxies_list)
         return proxy_flag, working_proxies
 
-def solid_google_dorking(query, proxy_flag, proxies_list, pages=1):
+
+def create_dorking_driver(proxy_flag, proxies_list):
+    config_values = read_config()
+    options = uc.ChromeOptions()
+    browser_binary = resolve_browser_binary(config_values['dorking_browser'])
+    browser_major_version = resolve_browser_major_version(browser_binary)
+    if browser_binary:
+        options.binary_location = browser_binary
+    dorking_browser_mode = config_values['dorking_browser_mode']
+    if dorking_browser_mode.lower() == 'headless':
+        options.add_argument("--headless=new")
+    options.add_argument("--no-sandbox")
+    options.add_argument("--disable-dev-shm-usage")
+    options.add_argument("--disable-blink-features=AutomationControlled")
+    options.add_argument("--disable-infobars")
+    options.add_argument("--disable-extensions")
+    options.add_argument(f"user-agent={user_agent_rotator.get_random_user_agent()}")
+    if proxy_flag == 1:
+        proxy = proxies_rotator.get_random_proxy(proxies_list)
+        options.add_argument(f'--proxy-server={proxy["http"]}')
+    chrome_kwargs = {'options': options}
+    if browser_binary:
+        chrome_kwargs['browser_executable_path'] = browser_binary
+    if browser_major_version:
+        chrome_kwargs['version_main'] = browser_major_version
+    return uc.Chrome(**chrome_kwargs), dorking_browser_mode
+
+def solid_google_dorking(query, proxy_flag, proxies_list, pages=1, driver=None, dorking_browser_mode=None):
     result_query = []
     request_count = 0
+    own_driver = driver is None
     try:
-        config_values = read_config()
-        options = uc.ChromeOptions()
-        options.binary_location = r"{}".format(config_values['dorking_browser'])
-        dorking_browser_mode = config_values['dorking_browser_mode']
-        if dorking_browser_mode.lower() == 'headless':
-            options.add_argument("--headless=new")
-        elif dorking_browser_mode.lower() == 'nonheadless':
-            pass
-        options.add_argument("--no-sandbox")
-        options.add_argument("--disable-dev-shm-usage")
-        options.add_argument("--disable-blink-features=AutomationControlled")
-        options.add_argument("--disable-infobars")
-        options.add_argument("--disable-extensions")
-        options.add_argument(f"user-agent={user_agent_rotator.get_random_user_agent()}")
-        if proxy_flag == 1:
-            proxy = proxies_rotator.get_random_proxy(proxies_list)
-            options.add_argument(f'--proxy-server={proxy["http"]}')
-        driver = uc.Chrome(options=options)
+        if own_driver:
+            driver, dorking_browser_mode = create_dorking_driver(proxy_flag, proxies_list)
         for page in range(pages):
             try:
                 driver.get("https://www.google.com")
                 time.sleep(random.uniform(2, 4))
+                if is_google_block_page(driver):
+                    block_result = handle_google_block(driver, query, dorking_browser_mode)
+                    if block_result == GOOGLE_BLOCKED:
+                        return block_result
                 try:
                     accepted = False
                     try:
@@ -88,6 +189,10 @@ def solid_google_dorking(query, proxy_flag, proxies_list, pages=1):
                 time.sleep(random.uniform(0.5, 1.2))
                 search_box.send_keys(Keys.RETURN)
                 time.sleep(random.uniform(2.5, 4))
+                if is_google_block_page(driver):
+                    block_result = handle_google_block(driver, query, dorking_browser_mode)
+                    if block_result == GOOGLE_BLOCKED:
+                        return block_result
                 links = driver.find_elements(By.CSS_SELECTOR, 'a')
                 for link in links:
                     href = link.get_attribute('href')
@@ -103,7 +208,6 @@ def solid_google_dorking(query, proxy_flag, proxies_list, pages=1):
             except Exception as e:
                 logging.error(f'DORKING PROCESSING (SELENIUM): ERROR. REASON: {e}')
                 continue
-        driver.quit()
         if len(result_query) >= 2:
             del result_query[-2:]
         return result_query
@@ -111,6 +215,9 @@ def solid_google_dorking(query, proxy_flag, proxies_list, pages=1):
         logging.error(f'DORKING PROCESSING: ERROR. REASON: {e}')
         print(Fore.RED + "Error while running Selenium dorking. See journal for details." + Style.RESET_ALL)
         return []
+    finally:
+        if own_driver and driver:
+            driver.quit()
 
 def save_results_to_txt(folderpath, table, queries, pages=1):
     try:
@@ -124,28 +231,39 @@ def save_results_to_txt(folderpath, table, queries, pages=1):
             print(Fore.GREEN + "Started Google Dorking. Please, be patient, it may take some time")
             print(Fore.GREEN + f"{dorking_delay} seconds delay after each {delay_step} dorking requests was configured" + Style.RESET_ALL)
             proxy_flag, proxies_list = proxy_transfer()
+            driver, dorking_browser_mode = create_dorking_driver(proxy_flag, proxies_list)
             dorked_query_counter = 0
-            for i, query in enumerate(queries, start=1):
-                f.write(f"QUERY #{i}: {query}\n")
-                try:
-                    results = solid_google_dorking(query, proxy_flag, proxies_list, pages)
-                    if not results:
-                        f.write("=> NO RESULT FOUND\n")
+            try:
+                for i, query in enumerate(queries, start=1):
+                    f.write(f"QUERY #{i}: {query}\n")
+                    try:
+                        results = solid_google_dorking(query, proxy_flag, proxies_list, pages, driver=driver, dorking_browser_mode=dorking_browser_mode)
+                        if results == GOOGLE_BLOCKED:
+                            f.write("=> GOOGLE BLOCK PAGE DETECTED. AUTOMATED DORKING STOPPED\n")
+                            total_results.append((query, 'blocked'))
+                            f.write("\n")
+                            break
+                        if not results:
+                            f.write("=> NO RESULT FOUND\n")
+                            total_results.append((query, 0))
+                        else:
+                            total_results.append((query, len(results)))
+                            for result in results:
+                                f.write(f"=> {result}\n")
+                    except Exception as e:
+                        logging.error(f"DORKING PROCESSING: ERROR. REASON: {e}")
                         total_results.append((query, 0))
-                    else:
-                        total_results.append((query, len(results)))
-                        for result in results:
-                            f.write(f"=> {result}\n")
-                except Exception as e:
-                    logging.error(f"DORKING PROCESSING: ERROR. REASON: {e}")
-                    total_results.append((query, 0))
-                f.write("\n")
-                dorked_query_counter += 1
-                print(Fore.GREEN + f"  Dorking with " + Style.RESET_ALL + Fore.LIGHTCYAN_EX + Style.BRIGHT + f"{dorked_query_counter}/{total_dorks_amount}" + Style.RESET_ALL + Fore.GREEN + " dork" + Style.RESET_ALL, end="\r")
+                    f.write("\n")
+                    dorked_query_counter += 1
+                    print(Fore.GREEN + f"  Dorking with " + Style.RESET_ALL + Fore.LIGHTCYAN_EX + Style.BRIGHT + f"{dorked_query_counter}/{total_dorks_amount}" + Style.RESET_ALL + Fore.GREEN + " dork" + Style.RESET_ALL, end="\r")
+            finally:
+                driver.quit()
         print(Fore.GREEN + "\nGoogle Dorking end. Results successfully saved in HTML report\n" + Style.RESET_ALL)
         print(Fore.GREEN + f"During Google Dorking with {table.upper()}:")
         for query, count in total_results:
-            if count == 0:
+            if count == 'blocked':
+                print(Fore.GREEN + f"[+] Google blocked automated dorking at query " + Fore.LIGHTCYAN_EX + f'{query}' + Fore.GREEN + '. ' + Fore.LIGHTYELLOW_EX + 'Scan stopped before continuing through the remaining dorks.' + Style.RESET_ALL)
+            elif count == 0:
                 count = 'no results'
                 print(Fore.GREEN + f"[+] Found results for " + Fore.LIGHTCYAN_EX + f'{query}' + Fore.GREEN + ' query: ' + Fore.LIGHTRED_EX + f'{count}' + Style.RESET_ALL)
             else:
@@ -163,20 +281,28 @@ def transfer_results_to_xlsx(table, queries, pages=10):
     print(Fore.GREEN + "Started Google Dorking. Please, be patient, it may take some time")
     print(Fore.GREEN + f"{dorking_delay} seconds delay after each {delay_step} dorking requests was configured" + Style.RESET_ALL)
     proxy_flag, proxies_list = proxy_transfer()
+    driver, dorking_browser_mode = create_dorking_driver(proxy_flag, proxies_list)
     dorked_query_counter = 0
     total_dorks_amount = len(queries)
     dorking_return_list = []
-    for i, query in enumerate(queries, start=1):
-        dorking_return_list.append(f"QUERY #{i}: {query}\n")
-        results = solid_google_dorking(query, dorking_delay, delay_step, proxy_flag, proxies_list)
-        if not results:
-            dorking_return_list.append("NO RESULT FOUND\n")
-        else:
-            for result in results:
-                dorking_return_list.append(f"{result}\n")
-        dorked_query_counter += 1
-        dorking_return_list.append("\n")
-        print(Fore.GREEN + f"  Dorking with " + Style.RESET_ALL + Fore.LIGHTCYAN_EX + Style.BRIGHT + f"{dorked_query_counter}/{total_dorks_amount}" + Style.RESET_ALL + Fore.GREEN + " dork" + Style.RESET_ALL, end="\r")
+    try:
+        for i, query in enumerate(queries, start=1):
+            dorking_return_list.append(f"QUERY #{i}: {query}\n")
+            results = solid_google_dorking(query, proxy_flag, proxies_list, pages, driver=driver, dorking_browser_mode=dorking_browser_mode)
+            if results == GOOGLE_BLOCKED:
+                dorking_return_list.append("GOOGLE BLOCK PAGE DETECTED. AUTOMATED DORKING STOPPED\n")
+                dorking_return_list.append("\n")
+                break
+            if not results:
+                dorking_return_list.append("NO RESULT FOUND\n")
+            else:
+                for result in results:
+                    dorking_return_list.append(f"{result}\n")
+            dorked_query_counter += 1
+            dorking_return_list.append("\n")
+            print(Fore.GREEN + f"  Dorking with " + Style.RESET_ALL + Fore.LIGHTCYAN_EX + Style.BRIGHT + f"{dorked_query_counter}/{total_dorks_amount}" + Style.RESET_ALL + Fore.GREEN + " dork" + Style.RESET_ALL, end="\r")
+    finally:
+        driver.quit()
     print(Fore.GREEN + "\nGoogle Dorking end. Results successfully saved in XLSX report\n" + Style.RESET_ALL)
     return f'Successfully dorked domain with {table.upper()} dorks table', dorking_return_list
 


### PR DESCRIPTION
## Summary

Four independent bugs fixed across the dorking and data-gathering modules. All changes are backward-compatible and tested with a full scan against a real domain.

---

### 1. Chromium binary auto-discovery (Linux compatibility)
**File:** `dorking/dorking_handler.py`

`undetected_chromedriver` couldn't locate the Chromium binary on Debian/Kali/Ubuntu systems where it lives at `/usr/bin/chromium` or `/usr/bin/chromium-browser`. Added `resolve_browser_binary()` which searches a list of known Linux paths and falls back to `which chromium` before returning the path to `uc.Chrome`.

### 2. ChromeDriver version pinning
**File:** `dorking/dorking_handler.py`

When the installed Chromium version differs from whatever `webdriver-manager` downloads (e.g. browser=145, driver=148), Chrome refuses to start. Added `resolve_browser_major_version()` which reads the major version from the binary and passes it as `version_main` to `uc.Chrome`, ensuring the matching driver is fetched.

### 3. Google CAPTCHA / block-page handling
**File:** `dorking/dorking_handler.py`

If Google returns a CAPTCHA or "unusual traffic" page the tool previously crashed or produced empty results silently. Changes:
- `is_google_block_page()` detects block pages by page title and URL pattern.
- `handle_google_block()` keeps the browser window open and polls every 10 s for up to 300 s while the user solves the CAPTCHA manually.
- Driver is created once per dork session (outer loop) rather than once per query, so the browser window is not destroyed between queries.

### 4. Subdomain sentinel string replaced with empty list
**File:** `datagather_modules/crawl_processor.py`

`subdomains_gather()` previously returned `['No subdomains were found']` on failure. Downstream code iterated over this list and used each item as a hostname, causing spurious DNS lookups and network errors for the fake host. Changed the return value to `[]` and updated `domains_reverse_research()` to skip empty/invalid hosts gracefully.

### 5. SecurityTrails → PageSearch fallback
**Files:** `datagather_modules/data_assembler.py`, `apis/api_securitytrails.py`

When the web crawl found no subdomains, PageSearch was silently skipped even if SecurityTrails had already returned subdomains earlier in the scan. Added a fallback path in `data_assembler.py` that re-queries SecurityTrails (if the API key is configured) and feeds those subdomains to PageSearch. `api_securitytrails_check()` now accepts `return_subdomains=True` to expose the subdomain list to the caller.

---

## Testing

Verified with a full scan (`dpulse.py`, scan mode 1) against a live domain:
- Google dorking returned results across 47 dork queries (23/47/28 hits)
- SecurityTrails returned 12 subdomains; 3 alive
- PageSearch ran on all 3 alive subdomains
- No sentinel-related DNS errors in output